### PR TITLE
Apply policies based on task prefix

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -30,7 +30,7 @@ func pathLogin(b *mesosBackend) *framework.Path {
 // pathLogin (the method) is the "login" path request handler.
 func (b *mesosBackend) pathLogin(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 	taskID := d.Get("task-id").(string)
-	if !verifyTaskExists(taskID) {
+	if !b.verifyTaskExists(taskID) {
 		return nil, logical.ErrPermissionDenied
 	}
 
@@ -64,11 +64,12 @@ func (b *mesosBackend) authRenew(ctx context.Context, req *logical.Request, d *f
 	return &logical.Response{Auth: req.Auth}, nil
 }
 
-func verifyTaskExists(taskID string) bool {
+func (b *mesosBackend) verifyTaskExists(taskID string) bool {
 	if taskID == "" {
 		return false
 	}
 
+	b.Logger().Debug("TODO: Check task in mesos.")
 	// TODO: Verify that the task exists.
 	return true
 }
@@ -85,6 +86,7 @@ func getTaskPolicies(ctx context.Context, storage logical.Storage, taskPrefix st
 
 	var tp taskPolicies
 	if err := se.DecodeJSON(&tp); err != nil {
+		// noqa: (Not actually a tag that does anything, sadly.)
 		return nil, err
 	}
 	return tp.Policies, nil

--- a/auth.go
+++ b/auth.go
@@ -98,11 +98,8 @@ func getTaskPolicies(ctx context.Context, storage logical.Storage, taskPrefix st
 	}
 
 	var tp taskPolicies
-	if err := se.DecodeJSON(&tp); err != nil {
-		// noqa: (Not actually a tag that does anything, sadly.)
-		return nil, err
-	}
-	return tp.Policies, nil
+	err = se.DecodeJSON(&tp)
+	return tp.Policies, err
 }
 
 func taskIDPrefix(taskID string) (string, error) {

--- a/auth.go
+++ b/auth.go
@@ -110,7 +110,7 @@ func taskIDPrefix(taskID string) (string, error) {
 	idx := strings.LastIndex(taskID, ".")
 	if idx < 1 {
 		// We have no task prefix (no dot or nothing before the last dot).
-		return "", fmt.Errorf("malformed task-id")
+		return "", fmt.Errorf("malformed task-id: \"%s\"", taskID)
 	}
 	return taskID[0:idx], nil
 }

--- a/auth.go
+++ b/auth.go
@@ -77,6 +77,8 @@ func (b *mesosBackend) authRenew(ctx context.Context, req *logical.Request, d *f
 	return &logical.Response{Auth: req.Auth}, nil
 }
 
+// verifyTaskExists checks that a taskID is valid and identifies an existing
+// task.
 func (b *mesosBackend) verifyTaskExists(taskID string) bool {
 	if taskID == "" {
 		return false
@@ -87,6 +89,7 @@ func (b *mesosBackend) verifyTaskExists(taskID string) bool {
 	return temporarySetOfExistingTasks[taskID]
 }
 
+// getTaskPolicies fetches the policies for a taskID prefix.
 func getTaskPolicies(ctx context.Context, storage logical.Storage, taskPrefix string) ([]string, error) {
 	se, err := storage.Get(ctx, tpKey(taskPrefix))
 	if err != nil {
@@ -102,6 +105,7 @@ func getTaskPolicies(ctx context.Context, storage logical.Storage, taskPrefix st
 	return tp.Policies, err
 }
 
+// taskIDPrefix extracts the prefix from a taskID.
 func taskIDPrefix(taskID string) (string, error) {
 	idx := strings.LastIndex(taskID, ".")
 	if idx < 1 {

--- a/auth_test.go
+++ b/auth_test.go
@@ -11,39 +11,27 @@ import (
 func (ts *TestSuite) Test_login_no_taskID() {
 	ts.SetupBackend()
 	req := ts.mkReq("login", jsonobj{})
-
-	resp, err := ts.HandleRequest(req)
-	ts.EqualError(err, "permission denied")
-	ts.Nil(resp)
+	ts.HandleRequestError(req, "permission denied")
 }
 
 func (ts *TestSuite) Test_login_missing_taskID() {
 	ts.SetupBackend()
 	req := ts.mkReq("login", jsonobj{"task-id": "missing-task.abc-123"})
-
-	resp, err := ts.HandleRequest(req)
-	ts.EqualError(err, "permission denied")
-	ts.Nil(resp)
+	ts.HandleRequestError(req, "permission denied")
 }
 
 func (ts *TestSuite) Test_login_taskID_with_no_prefix() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["abc-123"] = true
 	req := ts.mkReq("login", jsonobj{"task-id": "abc-123"})
-
-	resp, err := ts.HandleRequest(req)
-	ts.EqualError(err, "permission denied")
-	ts.Nil(resp)
+	ts.HandleRequestError(req, "permission denied")
 }
 
 func (ts *TestSuite) Test_login_unregistered_taskID() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["unregistered-task.abc-123"] = true
 	req := ts.mkReq("login", jsonobj{"task-id": "unregistered-task.abc-123"})
-
-	resp, err := ts.HandleRequest(req)
-	ts.EqualError(err, "permission denied")
-	ts.Nil(resp)
+	ts.HandleRequestError(req, "permission denied")
 }
 
 func (ts *TestSuite) Test_login_good_taskID() {
@@ -53,8 +41,7 @@ func (ts *TestSuite) Test_login_good_taskID() {
 
 	req := ts.mkReq("login", jsonobj{"task-id": "task-that-exists.abc-123"})
 
-	resp, err := ts.HandleRequest(req)
-	ts.Require().NoError(err)
+	resp := ts.HandleRequest(req)
 	ts.Nil(resp.Warnings)
 	ts.Nil(resp.Secret)
 	ts.Equal(resp.Auth, &logical.Auth{
@@ -75,9 +62,7 @@ func (ts *TestSuite) Test_renewal_not_logged_in() {
 		Unauthenticated: false,
 	}
 
-	resp, err := ts.HandleRequest(req)
-	ts.EqualError(err, "request has no secret")
-	ts.Nil(resp)
+	ts.HandleRequestError(req, "request has no secret")
 }
 
 func (ts *TestSuite) Test_renewal_logged_in() {
@@ -93,8 +78,7 @@ func (ts *TestSuite) Test_renewal_logged_in() {
 		Unauthenticated: false,
 	}
 
-	resp, err := ts.HandleRequest(req)
-	ts.NoError(err)
+	resp := ts.HandleRequest(req)
 	ts.Equal(auth, resp.Auth)
 }
 
@@ -112,7 +96,5 @@ func (ts *TestSuite) Test_renewal_task_ended() {
 		Unauthenticated: false,
 	}
 
-	resp, err := ts.HandleRequest(req)
-	ts.EqualError(err, "task short-task.abc-123 not found during renewal")
-	ts.Nil(resp)
+	ts.HandleRequestError(req, "task short-task.abc-123 not found during renewal")
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -26,6 +26,16 @@ func (ts *TestSuite) Test_login_missing_taskID() {
 	ts.Nil(resp)
 }
 
+func (ts *TestSuite) Test_login_taskID_with_no_prefix() {
+	ts.SetupBackend()
+	temporarySetOfExistingTasks["abc-123"] = true
+	req := ts.mkReq("login", jsonobj{"task-id": "abc-123"})
+
+	resp, err := ts.HandleRequest(req)
+	ts.EqualError(err, "permission denied")
+	ts.Nil(resp)
+}
+
 func (ts *TestSuite) Test_login_unregistered_taskID() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["unregistered-task.abc-123"] = true

--- a/auth_test.go
+++ b/auth_test.go
@@ -8,7 +8,7 @@ import (
 
 // See helper_for_test.go for common infrastructure and tools.
 
-func (ts *TestSuite) Test_login_no_task_id() {
+func (ts *TestSuite) Test_login_no_taskID() {
 	ts.SetupBackend()
 	req := ts.mkReq("login", jsonobj{})
 
@@ -17,16 +17,27 @@ func (ts *TestSuite) Test_login_no_task_id() {
 	ts.Nil(resp)
 }
 
-func (ts *TestSuite) Test_login_good_task_id() {
+func (ts *TestSuite) Test_login_unregistered_taskID() {
 	ts.SetupBackend()
-	req := ts.mkReq("login", jsonobj{"task-id": "task-that-exists"})
+	req := ts.mkReq("login", jsonobj{"task-id": "unregistered-task.abc-123"})
+
+	resp, err := ts.HandleRequest(req)
+	ts.EqualError(err, "permission denied")
+	ts.Nil(resp)
+}
+
+func (ts *TestSuite) Test_login_good_taskID() {
+	ts.SetupBackend()
+	ts.SetTaskPolicies("task-that-exists", "insurance")
+
+	req := ts.mkReq("login", jsonobj{"task-id": "task-that-exists.abc-123"})
 
 	resp, err := ts.HandleRequest(req)
 	ts.Require().NoError(err)
 	ts.Nil(resp.Warnings)
 	ts.Nil(resp.Secret)
 	ts.Equal(resp.Auth, &logical.Auth{
-		Policies:     []string{},
+		Policies:     []string{"insurance"},
 		Period:       10 * time.Minute,
 		LeaseOptions: logical.LeaseOptions{Renewable: true},
 	})
@@ -49,7 +60,8 @@ func (ts *TestSuite) Test_renewal_not_logged_in() {
 
 func (ts *TestSuite) Test_renewal_logged_in() {
 	ts.SetupBackend()
-	auth := ts.Login("logged-in-task")
+	ts.SetTaskPolicies("logged-in-task", "foreign")
+	auth := ts.Login("logged-in-task.abc-123")
 
 	req := &logical.Request{
 		Operation:       "renew",

--- a/auth_test.go
+++ b/auth_test.go
@@ -8,18 +8,21 @@ import (
 
 // See helper_for_test.go for common infrastructure and tools.
 
+// Can't log in without a taskID.
 func (ts *TestSuite) Test_login_no_taskID() {
 	ts.SetupBackend()
 	req := ts.mkReq("login", jsonobj{})
 	ts.HandleRequestError(req, "permission denied")
 }
 
+// Can't log in with a taskID that doesn't exist.
 func (ts *TestSuite) Test_login_missing_taskID() {
 	ts.SetupBackend()
 	req := ts.mkReq("login", jsonobj{"task-id": "missing-task.abc-123"})
 	ts.HandleRequestError(req, "permission denied")
 }
 
+// Can't log in with a taskID that doesn't have a Marathon-style app prefix.
 func (ts *TestSuite) Test_login_taskID_with_no_prefix() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["abc-123"] = true
@@ -27,6 +30,8 @@ func (ts *TestSuite) Test_login_taskID_with_no_prefix() {
 	ts.HandleRequestError(req, "permission denied")
 }
 
+// Can't log in with a taskID that doesn't have policies configured for its
+// prefix.
 func (ts *TestSuite) Test_login_unregistered_taskID() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["unregistered-task.abc-123"] = true
@@ -34,6 +39,8 @@ func (ts *TestSuite) Test_login_unregistered_taskID() {
 	ts.HandleRequestError(req, "permission denied")
 }
 
+// Can log in with a taskID that exists and has policies configured for its
+// prefix.
 func (ts *TestSuite) Test_login_good_taskID() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["task-that-exists.abc-123"] = true
@@ -52,6 +59,7 @@ func (ts *TestSuite) Test_login_good_taskID() {
 	})
 }
 
+// Can't renew if you're not logged in.
 func (ts *TestSuite) Test_renewal_not_logged_in() {
 	ts.SetupBackend()
 
@@ -65,6 +73,7 @@ func (ts *TestSuite) Test_renewal_not_logged_in() {
 	ts.HandleRequestError(req, "request has no secret")
 }
 
+// Can renew if you are logged in and your task still exists.
 func (ts *TestSuite) Test_renewal_logged_in() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["logged-in-task.abc-123"] = true
@@ -82,6 +91,7 @@ func (ts *TestSuite) Test_renewal_logged_in() {
 	ts.Equal(auth, resp.Auth)
 }
 
+// Can't renew if your task no longer exists.
 func (ts *TestSuite) Test_renewal_task_ended() {
 	ts.SetupBackend()
 	temporarySetOfExistingTasks["short-task.abc-123"] = true

--- a/backend.go
+++ b/backend.go
@@ -29,10 +29,12 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		Clean:      b.cleanup,
 	}
 
-	if err := b.Setup(ctx, conf); err != nil {
-		return nil, err
-	}
-	return &b, nil
+	// We unconditionally return &b and whatever error we got from the setup
+	// call to avoid some useless error handler boilerplate that we can't test.
+	// (Let's hope the caller doesn't assume an error response will always
+	// accompany a nil backend.)
+	err := b.Setup(ctx, conf)
+	return &b, err
 }
 
 // TODO: Make this useful or get rid of it.

--- a/backend.go
+++ b/backend.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
+// mesosBackend is our plugin backend object.
 type mesosBackend struct {
 	*framework.Backend
 }

--- a/backend.go
+++ b/backend.go
@@ -23,6 +23,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 		},
 		Paths: []*framework.Path{
 			pathLogin(&b),
+			pathTaskPolicies(&b),
 		},
 		Invalidate: b.invalidate,
 		Clean:      b.cleanup,

--- a/backend_test.go
+++ b/backend_test.go
@@ -8,6 +8,7 @@ import (
 
 // See helper_for_test.go for common infrastructure and tools.
 
+// The purpose of the factory is to build backends.
 func (ts *TestSuite) Test_Factory_builds_backend() {
 	b, err := Factory(context.Background(), &logical.BackendConfig{})
 	ts.NoError(err)

--- a/helper_for_test.go
+++ b/helper_for_test.go
@@ -98,3 +98,9 @@ func (ts *TestSuite) Login(taskID string) *logical.Auth {
 	resp := ts.WithoutError(ts.HandleRequest(req)).(*logical.Response)
 	return resp.Auth
 }
+
+func (ts *TestSuite) ResponseError(resp *logical.Response, errMsg string) {
+	ts.Nil(resp.Auth)
+	ts.Nil(resp.Secret)
+	ts.Equal(resp.Data, jsonobj{"error": errMsg})
+}

--- a/helper_for_test.go
+++ b/helper_for_test.go
@@ -12,10 +12,6 @@ import (
 
 // This file contains infrastructure and tools common to multiple tests.
 
-// jsonobj is an alias for type a JSON object gets unmarshalled into, because
-// building nested map[string]interface{}{ ... } literals is awful.
-type jsonobj = map[string]interface{}
-
 // TestSuite is a testify test suite object that we can attach helper methods
 // to.
 type TestSuite struct {
@@ -43,6 +39,9 @@ func (ts *TestSuite) SetupTest() {
 	ts.cleanups = []func(){}
 	ts.storage = nil
 	ts.backend = nil
+
+	// Clear our hacky task set global for each test.
+	temporarySetOfExistingTasks = map[string]bool{}
 }
 
 // TearDownTest calls the registered cleanup functions.

--- a/helper_for_test.go
+++ b/helper_for_test.go
@@ -121,3 +121,12 @@ func (ts *TestSuite) mkStorageEntry(key string, value interface{}) *logical.Stor
 func (ts *TestSuite) StoredEqual(key string, expected interface{}) {
 	ts.Equal(ts.GetStored(key), ts.mkStorageEntry(key, expected))
 }
+
+// Set task policies through the API.
+func (ts *TestSuite) SetTaskPolicies(taskPrefix string, policies ...string) {
+	ts.HandleRequestSuccess(ts.mkReq("task-policies", tpParams(taskPrefix, policies)))
+}
+
+func tpParams(taskPrefix string, policies interface{}) jsonobj {
+	return jsonobj{"task-id-prefix": taskPrefix, "policies": policies}
+}

--- a/helper_for_test.go
+++ b/helper_for_test.go
@@ -22,6 +22,8 @@ type TestSuite struct {
 	backend *mesosBackend
 }
 
+// Test_TestSuite is a standard Go test function that runs our test suite's
+// tests.
 func Test_TestSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }
@@ -74,6 +76,7 @@ func (ts *TestSuite) SetupBackend() {
 	ts.backend = ts.WithoutError(Factory(context.Background(), config)).(*mesosBackend)
 }
 
+// mkReq builds a basic request object.
 func (ts *TestSuite) mkReq(path string, data jsonobj) *logical.Request {
 	return &logical.Request{
 		Operation:  logical.UpdateOperation,
@@ -123,6 +126,7 @@ func (ts *TestSuite) GetStored(key string) *logical.StorageEntry {
 	return ts.WithoutError(ts.storage.Get(context.Background(), key)).(*logical.StorageEntry)
 }
 
+// mkStorageEntry builds a StorageEntry object with errors handled.
 func (ts *TestSuite) mkStorageEntry(key string, value interface{}) *logical.StorageEntry {
 	return ts.WithoutError(logical.StorageEntryJSON(key, value)).(*logical.StorageEntry)
 }
@@ -133,11 +137,12 @@ func (ts *TestSuite) StoredEqual(key string, expected interface{}) {
 	ts.Equal(ts.GetStored(key), ts.mkStorageEntry(key, expected))
 }
 
-// Set task policies through the API.
+// SetTaskPolicies sets task policies through the API.
 func (ts *TestSuite) SetTaskPolicies(taskPrefix string, policies ...string) {
 	ts.HandleRequestSuccess(ts.mkReq("task-policies", tpParams(taskPrefix, policies)))
 }
 
+// tpParams removes boilerplate from request creation.
 func tpParams(taskPrefix string, policies interface{}) jsonobj {
 	return jsonobj{"task-id-prefix": taskPrefix, "policies": policies}
 }

--- a/task_policies.go
+++ b/task_policies.go
@@ -7,10 +7,9 @@ import (
 	"github.com/hashicorp/vault/logical/framework"
 )
 
-// pathTaskPolicies (the function) returns the "task-policies" path struct. It
-// is a function rather than a method because we never call it once the backend
-// struct is built and we don't want name collisions with any request handler
-// methods.
+// pathTaskPolicies returns the "task-policies" path struct. It is a function
+// rather than a method because we never call it once the backend struct is
+// built and we don't want name collisions with any request handler methods.
 func pathTaskPolicies(b *mesosBackend) *framework.Path {
 	return &framework.Path{
 		Pattern: "task-policies",
@@ -36,8 +35,7 @@ func tpKey(tip string) string {
 	return "task-policies/" + tip
 }
 
-// pathTaskPoliciesUpdate (the method) is the "task-policies" update request
-// handler.
+// pathTaskPoliciesUpdate is the "task-policies" update request handler.
 func (b *mesosBackend) pathTaskPoliciesUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
 
 	taskIDPrefix := d.Get("task-id-prefix").(string)

--- a/task_policies.go
+++ b/task_policies.go
@@ -50,16 +50,14 @@ func (b *mesosBackend) pathTaskPoliciesUpdate(ctx context.Context, req *logical.
 
 	b.Logger().Info("TASK POLICIES", "task-id-prefix", taskIDPrefix, "policies", policies)
 
-	storageEntry, err := logical.StorageEntryJSON(tpKey(taskIDPrefix), taskPolicies{policies})
-	if err != nil {
-		// noqa: (Not actually a tag that does anything, sadly.)
-		return nil, err
-	}
+	err := store(ctx, req.Storage, tpKey(taskIDPrefix), taskPolicies{policies})
+	return &logical.Response{}, err
+}
 
-	if err := req.Storage.Put(ctx, storageEntry); err != nil {
-		// noqa: (Not actually a tag that does anything, sadly.)
-		return nil, err
+func store(ctx context.Context, storage logical.Storage, key string, value interface{}) error {
+	storageEntry, err := logical.StorageEntryJSON(key, value)
+	if err == nil {
+		err = storage.Put(ctx, storageEntry)
 	}
-
-	return &logical.Response{}, nil
+	return err
 }

--- a/task_policies.go
+++ b/task_policies.go
@@ -27,10 +27,12 @@ func pathTaskPolicies(b *mesosBackend) *framework.Path {
 	}
 }
 
+// taskPolicies is used to store policies for a task.
 type taskPolicies struct {
 	Policies []string
 }
 
+// tpKey builds a task policy storage key.
 func tpKey(tip string) string {
 	return "task-policies/" + tip
 }
@@ -52,12 +54,4 @@ func (b *mesosBackend) pathTaskPoliciesUpdate(ctx context.Context, req *logical.
 
 	err := store(ctx, req.Storage, tpKey(taskIDPrefix), taskPolicies{policies})
 	return &logical.Response{}, err
-}
-
-func store(ctx context.Context, storage logical.Storage, key string, value interface{}) error {
-	storageEntry, err := logical.StorageEntryJSON(key, value)
-	if err == nil {
-		err = storage.Put(ctx, storageEntry)
-	}
-	return err
 }

--- a/task_policies.go
+++ b/task_policies.go
@@ -1,0 +1,48 @@
+package mesosAuthPlugin
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+// pathTaskPolicies (the function) returns the "task-policies" path struct. It
+// is a function rather than a method because we never call it once the backend
+// struct is built and we don't want name collisions with any request handler
+// methods.
+func pathTaskPolicies(b *mesosBackend) *framework.Path {
+	return &framework.Path{
+		Pattern: "task-policies",
+		Fields: map[string]*framework.FieldSchema{
+			"task-id-prefix": &framework.FieldSchema{
+				Type: framework.TypeString,
+			},
+			"policies": &framework.FieldSchema{
+				Type: framework.TypeCommaStringSlice,
+			},
+		},
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.UpdateOperation: b.pathTaskPoliciesUpdate,
+		},
+	}
+}
+
+// pathTaskPoliciesUpdate (the method) is the "task-policies" update request
+// handler.
+func (b *mesosBackend) pathTaskPoliciesUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+
+	taskIDPrefix := d.Get("task-id-prefix").(string)
+	if len(taskIDPrefix) < 1 {
+		return logical.ErrorResponse("missing or invalid task-id-prefix"), nil
+	}
+
+	policies := d.Get("policies").([]string)
+	if len(policies) < 1 {
+		return logical.ErrorResponse("missing or invalid policies"), nil
+	}
+
+	b.Logger().Info("TASK POLICIES", "task-id-prefix", taskIDPrefix, "policies", policies)
+
+	return &logical.Response{}, nil
+}

--- a/task_policies_test.go
+++ b/task_policies_test.go
@@ -18,6 +18,8 @@ var invalidParamData = []struct {
 	{"policies", jsonobj{"task-id-prefix": "my-task", "policies": []string{}}},
 }
 
+// Any missing or empty parameter causes a task-policies update request to
+// fail.
 func (ts *TestSuite) Test_taskPolicies_invalid_params() {
 	ts.SetupBackend()
 	for _, ipd := range invalidParamData {
@@ -27,6 +29,7 @@ func (ts *TestSuite) Test_taskPolicies_invalid_params() {
 	}
 }
 
+// A task-policies update containing a single policy succeeds.
 func (ts *TestSuite) Test_taskPolicies_simple() {
 	ts.SetupBackend()
 	ts.Nil(ts.GetStored(tpKey("my-task")))

--- a/task_policies_test.go
+++ b/task_policies_test.go
@@ -22,7 +22,7 @@ func (ts *TestSuite) Test_taskPolicies_invalid_params() {
 	ts.SetupBackend()
 	for _, ipd := range invalidParamData {
 		req := ts.mkReq("task-policies", ipd.data)
-		resp := ts.WithoutError(ts.HandleRequest(req)).(*logical.Response)
+		resp := ts.HandleRequest(req)
 		ts.EqualError(resp.Error(), "missing or invalid "+ipd.field)
 	}
 }
@@ -33,7 +33,7 @@ func (ts *TestSuite) Test_taskPolicies_simple() {
 
 	req := ts.mkReq("task-policies", tpParams("my-task", "insurance"))
 
-	resp := ts.HandleRequestSuccess(req)
+	resp := ts.HandleRequest(req)
 	ts.Equal(resp, &logical.Response{})
 
 	ts.StoredEqual(tpKey("my-task"), taskPolicies{[]string{"insurance"}})

--- a/task_policies_test.go
+++ b/task_policies_test.go
@@ -1,5 +1,9 @@
 package mesosAuthPlugin
 
+import (
+	"github.com/hashicorp/vault/logical"
+)
+
 // See helper_for_test.go for common infrastructure and tools.
 
 var invalidParamData = []struct {
@@ -18,8 +22,23 @@ func (ts *TestSuite) Test_taskPolicies_invalid_params() {
 	ts.SetupBackend()
 	for _, ipd := range invalidParamData {
 		req := ts.mkReq("task-policies", ipd.data)
-		resp, err := ts.HandleRequest(req)
-		ts.NoError(err)
-		ts.ResponseError(resp, "missing or invalid "+ipd.field)
+		resp := ts.WithoutError(ts.HandleRequest(req)).(*logical.Response)
+		ts.EqualError(resp.Error(), "missing or invalid "+ipd.field)
 	}
+}
+
+func tpParams(tip string, policies interface{}) jsonobj {
+	return jsonobj{"task-id-prefix": tip, "policies": policies}
+}
+
+func (ts *TestSuite) Test_taskPolicies_simple() {
+	ts.SetupBackend()
+	ts.Nil(ts.GetStored(tpKey("my-task")))
+
+	req := ts.mkReq("task-policies", tpParams("my-task", "insurance"))
+
+	resp := ts.HandleRequestSuccess(req)
+	ts.Equal(resp, &logical.Response{})
+
+	ts.StoredEqual(tpKey("my-task"), taskPolicies{[]string{"insurance"}})
 }

--- a/task_policies_test.go
+++ b/task_policies_test.go
@@ -27,10 +27,6 @@ func (ts *TestSuite) Test_taskPolicies_invalid_params() {
 	}
 }
 
-func tpParams(tip string, policies interface{}) jsonobj {
-	return jsonobj{"task-id-prefix": tip, "policies": policies}
-}
-
 func (ts *TestSuite) Test_taskPolicies_simple() {
 	ts.SetupBackend()
 	ts.Nil(ts.GetStored(tpKey("my-task")))

--- a/task_policies_test.go
+++ b/task_policies_test.go
@@ -41,3 +41,17 @@ func (ts *TestSuite) Test_taskPolicies_simple() {
 
 	ts.StoredEqual(tpKey("my-task"), taskPolicies{[]string{"insurance"}})
 }
+
+// A task-policies update overwrites any existing policies for that task.
+func (ts *TestSuite) Test_taskPolicies_replace() {
+	ts.SetupBackend()
+	ts.Nil(ts.GetStored(tpKey("my-task")))
+
+	req1 := ts.mkReq("task-policies", tpParams("my-task", "insurance"))
+	ts.Equal(ts.HandleRequest(req1), &logical.Response{})
+	ts.StoredEqual(tpKey("my-task"), taskPolicies{[]string{"insurance"}})
+
+	req2 := ts.mkReq("task-policies", tpParams("my-task", "foreign"))
+	ts.Equal(ts.HandleRequest(req2), &logical.Response{})
+	ts.StoredEqual(tpKey("my-task"), taskPolicies{[]string{"foreign"}})
+}

--- a/task_policies_test.go
+++ b/task_policies_test.go
@@ -1,0 +1,25 @@
+package mesosAuthPlugin
+
+// See helper_for_test.go for common infrastructure and tools.
+
+var invalidParamData = []struct {
+	field string
+	data  jsonobj
+}{
+	{"task-id-prefix", jsonobj{}},
+	{"task-id-prefix", jsonobj{"policies": "insurance"}},
+	{"task-id-prefix", jsonobj{"task-id-prefix": ""}},
+	{"policies", jsonobj{"task-id-prefix": "my-task"}},
+	{"policies", jsonobj{"task-id-prefix": "my-task", "policies": ""}},
+	{"policies", jsonobj{"task-id-prefix": "my-task", "policies": []string{}}},
+}
+
+func (ts *TestSuite) Test_taskPolicies_invalid_params() {
+	ts.SetupBackend()
+	for _, ipd := range invalidParamData {
+		req := ts.mkReq("task-policies", ipd.data)
+		resp, err := ts.HandleRequest(req)
+		ts.NoError(err)
+		ts.ResponseError(resp, "missing or invalid "+ipd.field)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,8 @@
+package mesosAuthPlugin
+
+// This file contains random bits of code that don't really belong to any
+// particular thing.
+
+// jsonobj is an alias for type a JSON object gets unmarshalled into, because
+// building nested map[string]interface{}{ ... } literals is awful.
+type jsonobj = map[string]interface{}

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,22 @@ package mesosAuthPlugin
 // This file contains random bits of code that don't really belong to any
 // particular thing.
 
+import (
+	"context"
+
+	"github.com/hashicorp/vault/logical"
+)
+
 // jsonobj is an alias for type a JSON object gets unmarshalled into, because
 // building nested map[string]interface{}{ ... } literals is awful.
 type jsonobj = map[string]interface{}
+
+// store is a helper function to construct and store a Vault storage entry so
+// we can avoid boilerplate in all the places we do this.
+func store(ctx context.Context, storage logical.Storage, key string, value interface{}) error {
+	storageEntry, err := logical.StorageEntryJSON(key, value)
+	if err == nil {
+		err = storage.Put(ctx, storageEntry)
+	}
+	return err
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// A human-readable version string does not contain a version suffix if there
+// is no prerelease string.
 func Test_HumanReadable_no_prerelease(t *testing.T) {
 	// Override global variables (usually set at compile time).
 	GitCommit = "abc123+CHANGES"
@@ -17,6 +19,8 @@ func Test_HumanReadable_no_prerelease(t *testing.T) {
 	assert.NotContains(t, hr, "Version: "+Version+"-")
 }
 
+// A human-readable version string contains a version suffix if there is a
+// prerelease string.
 func Test_HumanReadable_with_prerelease(t *testing.T) {
 	// Override global variables (usually set at compile time).
 	GitCommit = "abc123"


### PR DESCRIPTION
The main purpose of this PR is to add support for task policies based on the task prefix, which is (as far as I can tell) shared by all tasks belonging to a particular Marathon application.

The main parts of this are:
 * A new API for setting the policies for a task prefix. (Removal will come later, because that would ideally revoke existing tokens and such as well.)
 * The login API rejects requests for tasks that don't have a known prefix.
 * The login API checks a temporary in-memory set of "existing tasks" to simulate a call to Mesos. (This will be replaced with a better mechanism later.)
 * Assorted refactorings and shuffling-around-of-code in an attempt to avoid unnecessary boilerplate and untestable error handlers as far as possible.